### PR TITLE
SM-221: creating SBOM for simpad applications

### DIFF
--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -48,7 +48,7 @@ python do_dependencytrack_init() {
                 "type": "operating-system",
                 "bom-ref": hashlib.md5(d.getVar("MACHINE", False).encode()).hexdigest(),
                 "group": d.getVar("MACHINE", False),
-                "name": d.getVar("DISTRO_NAME", False),
+                "name": d.getVar("DISTRO_NAME", False) + "-" + d.getVar('MACHINE').replace("kontron-", ""),
                 "version": d.getVar("SECUREOS_RELEASE_VERSION", False)
             }
         },


### PR DESCRIPTION
- Merged changes from upstream
- fixed the issue with creating duplicate dependencies, making the json invalid (according to CyclonDX json scheme)
- made use of yocto `RDEPENDS` variable to get dependencies for non-system packages. Open source implementation only accounts for those 