### PR TITLE
SM-815: include patches into CyclonDx SBOM file generated by yocto

### DIFF
--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -195,7 +195,6 @@ python do_dependencytrack_upload() {
         return
 
     installed_pkgs = read_json(install_packages_file)
-    pkgs_names = list(installed_pkgs.keys())
 
     temp_dependencies_json = read_json(d.getVar("DEPENDENCYTRACK_TMP") + "/dependencies.json")
     for package, dependencies in temp_dependencies_json.items():

--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -26,11 +26,11 @@ DEPENDENCYTRACK_PROJECT_VERSION ??= ""
 DEPENDENCYTRACK_PARENT ??= ""
 DEPENDENCYTRACK_AUTO_CREATE ??= "false"
 
-DT_LICENSE_CONVERSION_MAP ??= "{ "GPLv2+" : "GPL-2.0-or-later", "GPLv2" : "GPL-2.0", "LGPLv2" : "LGPL-2.0", "LGPLv2+" : "LGPL-2.0-or-later", "LGPLv2.1+" : "LGPL-2.1-or-later", "LGPLv2.1" : "LGPL-2.1"}"
-
 python do_dependencytrack_init() {
     import uuid
     from datetime import datetime, timezone
+    from json_utils import write_sbom, write_vex
+    from sbom_details import get_bom_ref
 
     deptrack_dir = d.getVar("DEPENDENCYTRACK_DIR")
     if not os.path.exists(deptrack_dir):
@@ -68,9 +68,6 @@ python do_dependencytrack_init() {
         bb.debug(2, "Creating empty sbom")
         write_sbom(d, default_structure)
 
-        # Upload minimal sbom so that the project is created and is valid for vex upload later
-        upload_sbom(d)
-
     if not os.path.isfile(d.getVar("DEPENDENCYTRACK_VEX")):
         bb.debug(2, "Creating empty vex")
         write_vex(d, default_structure)
@@ -80,9 +77,10 @@ addhandler do_dependencytrack_init
 do_dependencytrack_init[eventmask] = "bb.event.BuildStarted"
 
 python do_dependencytrack_collect() {
-    import json
-    from pathlib import Path
     from oe.cve_check import get_patched_cves
+    from json_utils import read_json, write_json, read_sbom, read_vex, write_sbom, write_vex
+    from sbom_details import get_cpe_ids, get_bom_ref, get_references, get_licenses
+    from vex_handling import add_ignored_vulnerability, add_patched_vulnerability
 
     # load the bom
     name = d.getVar("CVE_PRODUCT")
@@ -94,8 +92,7 @@ python do_dependencytrack_collect() {
                        "-doc", "-src", "-locale", "-dev")
 
     cve_mapping_path = d.getVar("DEPENDENCYTRACK_TMP") + "/cve_mapping.json"
-    cve_mapping = read_json(d, cve_mapping_path) if os.path.exists(
-        cve_mapping_path) else dict()
+    cve_mapping = read_json(cve_mapping_path) if os.path.exists(cve_mapping_path) else dict()
 
     def map_component_cve_name_list(recipe_name):
         return cve_mapping.get(recipe_name, [recipe_name])
@@ -116,7 +113,7 @@ python do_dependencytrack_collect() {
             if license_json:
                 component_json["licenses"] = license_json
 
-            references = get_references(d)
+            references = get_references(d.getVar("SRC_URI").split(" "))
 
             if references:
                 component_json["externalReferences"] = references
@@ -146,8 +143,7 @@ python do_dependencytrack_collect() {
                 set(cve_mapping.get(d.getVar("BPN"), []) + cve_names))
 
     dependencies_path = d.getVar("DEPENDENCYTRACK_TMP") + "/dependencies.json"
-    temp_dependencies_json = read_json(
-        d, dependencies_path) if os.path.exists(dependencies_path) else dict()
+    temp_dependencies_json = read_json(dependencies_path) if os.path.exists(dependencies_path) else dict()
 
     part = d.getVar("CVE_PART")
 
@@ -166,15 +162,15 @@ python do_dependencytrack_collect() {
         for index, o in enumerate(get_cpe_ids(name, version, part)):
             add_component(o, temp_dependencies_json, name, version)
 
-    # write it back to the deploy directory
+    # write it back to the deployment directory
     write_sbom(d, sbom)
-    write_json(d, temp_dependencies_json, dependencies_path)
-    write_json(d, cve_mapping, cve_mapping_path)
+    write_json(dependencies_path, temp_dependencies_json)
+    write_json(cve_mapping_path, cve_mapping)
 
     # Collecting patched and ignored CVEs
     vex = read_vex(d)
     for patched_cve_id in get_patched_cves(d):
-        add_patched_vulnerabitily(vex, patched_cve_id)
+        add_patched_vulnerability(vex, patched_cve_id)
     for ignored_cve_id in d.getVar("CVE_CHECK_IGNORE").split():
         add_ignored_vulnerability(vex, ignored_cve_id)
     write_vex(d, vex)
@@ -186,24 +182,22 @@ do_dependencytrack_collect[lockfiles] += "${DEPENDENCYTRACK_LOCK}"
 do_rootfs[recrdeptask] += "do_dependencytrack_collect"
 
 python do_dependencytrack_upload() {
-    import json, base64, requests
-    from pathlib import Path
+    from sbom_details import get_bom_ref
+    from json_utils import read_sbom, read_vex, read_json, write_sbom, write_vex
 
     sbom = read_sbom(d)
     vex = read_vex(d)
 
-    install_packages_file = d.getVar(
-        "DEPENDENCYTRACK_TMP") + "/installed_packages.json"
+    install_packages_file = d.getVar("DEPENDENCYTRACK_TMP") + "/installed_packages.json"
 
     if not os.path.isfile(install_packages_file):
         bb.warn("No file: %s, build interrupted?" % install_packages_file)
         return
 
-    installed_pkgs = read_json(d, install_packages_file)
+    installed_pkgs = read_json(install_packages_file)
     pkgs_names = list(installed_pkgs.keys())
 
-    temp_dependencies_json = read_json(d, d.getVar(
-        "DEPENDENCYTRACK_TMP") + "/dependencies.json")
+    temp_dependencies_json = read_json(d.getVar("DEPENDENCYTRACK_TMP") + "/dependencies.json")
     for package, dependencies in temp_dependencies_json.items():
         if not installed_pkgs.get(package, None):
             installed_pkgs[package] = {"deps": dependencies}
@@ -218,11 +212,9 @@ python do_dependencytrack_upload() {
             for dep in pkg.get("deps", []):
                 dep_component = components_dict.get(dep)
                 if dep_component and dep_component["bom-ref"] != sbom_component["bom-ref"]:
-                    depend = next(
-                        (d for d in sbom["dependencies"] if d["ref"] == sbom_component["bom-ref"]), None)
+                    depend = next((d for d in sbom["dependencies"] if d["ref"] == sbom_component["bom-ref"]), None)
                     if depend is None:
-                        depend = {
-                            "ref": sbom_component["bom-ref"], "dependsOn": []}
+                        depend = {"ref": sbom_component["bom-ref"], "dependsOn": []}
                         depend["dependsOn"].append(dep_component["bom-ref"])
                         sbom["dependencies"].append(depend)
                     elif dep_component["bom-ref"] not in depend["dependsOn"]:
@@ -231,13 +223,12 @@ python do_dependencytrack_upload() {
     # Extract all ref values
     all_refs = {component["bom-ref"] for component in sbom["components"]}
     # Extract all dependsOn values
-    all_depends_on = {
-        ref for dependency in sbom["dependencies"] for ref in dependency.get("dependsOn", [])}
+    all_depends_on = {ref for dependency in sbom["dependencies"] for ref in dependency.get("dependsOn", [])}
     # Find refs that are not in dependsOn
-    refs_not_in_depends_on = all_refs - all_depends_on
+    refs_not_in_depends_on = list(all_refs - all_depends_on)
     # add dependencies for components that are not in dependsOn
-    sbom["dependencies"].append({"ref": get_bom_ref(d.getVar(
-        "MACHINE", False)), "dependsOn": list(refs_not_in_depends_on)})
+    if refs_not_in_depends_on:
+        sbom["dependencies"].append({"ref": get_bom_ref(d.getVar("MACHINE", False)), "dependsOn": refs_not_in_depends_on})
 
     write_sbom(d, sbom)
     upload_sbom(d)
@@ -248,9 +239,10 @@ python do_dependencytrack_upload() {
 
 python do_dependencytrack_installed() {
     from oe.rootfs import image_list_installed_packages
+    from json_utils import write_json
+
     pkgs = image_list_installed_packages(d)
-    write_json(d, pkgs, d.getVar("DEPENDENCYTRACK_TMP") +
-               "/installed_packages.json")
+    write_json(d.getVar("DEPENDENCYTRACK_TMP") + "/installed_packages.json", pkgs)
 }
 
 ROOTFS_POSTUNINSTALL_COMMAND += "do_dependencytrack_installed;"
@@ -259,134 +251,9 @@ addhandler do_dependencytrack_upload
 do_dependencytrack_upload[eventmask] = "bb.event.BuildCompleted"
 
 
-def read_sbom(d):
-    return read_json(d, d.getVar("DEPENDENCYTRACK_SBOM"))
-
-
-def read_vex(d):
-    return read_json(d, d.getVar("DEPENDENCYTRACK_VEX"))
-
-
-def read_json(d, path):
-    import json
-    from pathlib import Path
-    return json.loads(Path(path).read_text())
-
-
-def write_sbom(d, sbom):
-    write_json(d, sbom, d.getVar("DEPENDENCYTRACK_SBOM"))
-
-
-def write_vex(d, vex):
-    write_json(d, vex, d.getVar("DEPENDENCYTRACK_VEX"))
-
-
-def write_json(d, data, path):
-    import json
-    from pathlib import Path
-    Path(path).write_text(json.dumps(data, indent=2))
-
-
-def get_references(d):
-    import re
-    pattern = re.compile(
-        r"http[s]*:\/\/[a-z.]*\/[a-z.\-\/]*[a-z.\-].(tar.([gxl]?z|bz2)|tgz)")
-    src_uris = d.getVar("SRC_URI").split(" ")
-    refs = []
-    for src in src_uris:
-        if src.startswith("git://") or src.endswith(".git"):
-            refs.append({"type": "vcs", "url": src})
-
-        elif pattern.match(src):
-            refs.append({"type": "source-distribution", "url": src})
-
-        elif src.startswith("http://") or src.startswith("https://"):
-            refs.append({"type": "website", "url": src})
-
-    return refs
-
-
-def get_licenses(d):
-    import json
-    from pathlib import Path
-    license_expression = d.getVar("LICENSE")
-    if license_expression:
-        license_json = []
-        license_conversion_map = json.loads(
-            d.getVar("DT_LICENSE_CONVERSION_MAP"))
-        licenses = license_expression.replace("|", "").replace("&", "").split()
-        for license in licenses:
-            if license in license_conversion_map:
-                converted_license = license_conversion_map[license]
-            else:
-                converted_license = license
-            # Search for the license in COMMON_LICENSE_DIR and LICENSE_PATH
-            for directory in [d.getVar("COMMON_LICENSE_DIR")] + (d.getVar("LICENSE_PATH") or "").split():
-                try:
-                    with (Path(directory) / converted_license).open(errors="replace") as f:
-                        license_data = {"license": {"name": converted_license}}
-                        license_json.append(license_data)
-                        break
-                except FileNotFoundError:
-                    pass
-        return license_json
-    return None
-
-
-def get_cpe_ids(cve_product, version, part):
-    """
-    Get list of CPE identifiers for the given product and version
-    """
-
-    cpe_ids = []
-    for product in cve_product.split():
-        # CVE_PRODUCT in recipes may include vendor information for CPE identifiers. If not,
-        # use wildcard for vendor.
-        if ":" in product:
-            vendor, product = product.split(":", 1)
-        else:
-            vendor = "*"
-
-        cpe_id = 'cpe:2.3:{}:{}:{}:{}:*:*:*:*:*:*:*'.format(
-            part, vendor, product, version)
-        cpe_ids.append(type('', (object,), {
-                       "cpe": cpe_id, "product": product, "vendor": vendor if vendor != "*" else ""})())
-
-    return cpe_ids
-
-
-def add_patched_vulnerabitily(vex, cve_id):
-    vulnerability = next(
-        (v for v in vex["vulnerabilities"] if v["id"] == cve_id), None)
-    if vulnerability is None:
-        add_vulnerability(vex, cve_id, "resolved", "update",
-                          "CVE_CHECK data : The vulnerability has been Patched!")
-    else:  # (write to patched, even if already ignored)
-        vulnerability["analysis"].update({"state": "resolved", "response": [
-                                         "update"], "detail": "CVE_CHECK data: The vulnerability has been Patched!"})
-
-
-def add_ignored_vulnerability(vex, cve_id):
-    if next((v for v in vex["vulnerabilities"] if v["id"] == cve_id), None) is None:
-        add_vulnerability(vex, cve_id, "resolved", "will_not_fix",
-                          "CVE_CHECK data : The vulnerability has been Ignored!", "code_not_present")
-
-
-def add_vulnerability(vex, cve_id, analysis_state, analysis_response, analysis_detail, analysis_justification = None):
-    vulnerability = {
-            "id": cve_id,
-            "source": {"name": "NVD", "url": "https://nvd.nist.gov/"},
-            "analysis": {"state": analysis_state, "response": [analysis_response], "detail": analysis_detail},
-            "affects": [{"ref": vex["metadata"]["component"]["bom-ref"]}]
-    }
-        
-    if analysis_justification:
-        vulnerability["analysis"]["justification"] = analysis_justification
-           
-    vex["vulnerabilities"].append(vulnerability)
-
-
 def upload_sbom(d):
+    from dependency_track_requests import post_request
+
     dt_upload = bb.utils.to_boolean(d.getVar("DEPENDENCYTRACK_UPLOAD"))
     if not dt_upload:
         return
@@ -409,10 +276,12 @@ def upload_sbom(d):
     else:
         files["project"] = dt_project
 
-    post_request(dt_url, files)
+    post_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), files)
 
 
 def upload_vex(d):
+    from dependency_track_requests import post_request
+
     dt_upload = bb.utils.to_boolean(d.getVar("DEPENDENCYTRACK_UPLOAD"))
     if not dt_upload:
         return
@@ -429,28 +298,4 @@ def upload_vex(d):
     else:
         files["project"] = dt_project
 
-    post_request(dt_url, files)
-
-
-def post_request(url, files):
-    import requests
-    headers = {"X-API-Key": d.getVar("DEPENDENCYTRACK_API_KEY")}
-
-    try:
-        response = requests.post(url, headers=headers, files=files)
-        response.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        bb.error(
-            f"Failed to upload to Dependency Track server at {url}. [HTTP Error] {e}")
-        bb.error(f"Response: {response.status_code} -> {response.reason}")
-    except requests.exceptions.RequestException as e:
-        bb.error(
-            f"Failed to upload to Dependency Track server at {url}. [Error] {e}")
-    else:
-        bb.debug(2, f"File successfully uploaded to {url}")
-
-def get_bom_ref(value):
-    import uuid
-    import hashlib
-    bomhash = hashlib.md5(value.encode())
-    return str(uuid.UUID(bomhash.hexdigest()))
+    post_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), files)

--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -303,6 +303,10 @@ def get_projects_latest_version(d):
 def clone_project(d, uuid):
     from dependency_track_requests import put_request
 
+    dt_upload = bb.utils.to_boolean(d.getVar("DEPENDENCYTRACK_UPLOAD"))
+    if not dt_upload:
+        return
+
     dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + "/v1/project/clone"
 
     put_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"),

--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -149,18 +149,17 @@ python do_dependencytrack_collect() {
 
     # name is set to default, so CVE_PRODUCT not set
     if name == d.getVar("BPN"):
-        # there might be several packages in 1 recipe and some of them are needed to be filted out
+        # there might be several packages in 1 recipe and some of them are needed to be filtered out
         for package in filter(
             lambda s: all(
                 not s.endswith(suffix) for suffix in filter_suffixes
             ),
             d.getVar("PACKAGES").split()):
             # only 1 CPE product
-            add_component(get_cpe_ids(package, version, part)[
-                          0], temp_dependencies_json, package, version)
+            add_component(get_cpe_ids(package, version, part)[0], temp_dependencies_json, package, version)
     else:
-        for index, o in enumerate(get_cpe_ids(name, version, part)):
-            add_component(o, temp_dependencies_json, name, version)
+        for cpe_ids in get_cpe_ids(name, version, part):
+            add_component(cpe_ids, temp_dependencies_json, name, version)
 
     # write it back to the deployment directory
     write_sbom(d, sbom)
@@ -285,7 +284,7 @@ def upload_vex(d):
     if not dt_upload:
         return
 
-    dt_url = d.getVar('DEPENDENCYTRACK_API_URL') + "/v1/vex"
+    dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + "/v1/vex"
     dt_project = d.getVar("DEPENDENCYTRACK_PROJECT")
     dt_project_name = d.getVar("DEPENDENCYTRACK_PROJECT_NAME")
     dt_project_version = d.getVar("DEPENDENCYTRACK_PROJECT_VERSION")

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/lib/dependency_track_requests.py
+++ b/lib/dependency_track_requests.py
@@ -18,7 +18,7 @@ def post_request(bb, url: str, api_key: str, files: dict) -> None:
     except requests.exceptions.RequestException as e:
         bb.error(log_error_string + f"[Error] {e}")
     else:
-        bb.debug(2, f"File successfully uploaded to {url}")
+        bb.debug(2, f"File successfully uploaded to {url}. Response: {response.json()}")
 
 
 def get_request(bb, url: str, api_key: str, files: dict = None, params: dict = None) -> dict | int | None:

--- a/lib/dependency_track_requests.py
+++ b/lib/dependency_track_requests.py
@@ -1,0 +1,45 @@
+import requests
+
+
+def post_request(bb, url: str, api_key: str, files: dict) -> None:
+    headers = {"X-API-Key": api_key}
+    log_error_string = f"Failed to get from Dependency Track server at {url}, {files.keys() = }. "
+
+    try:
+        response = requests.post(url, headers=headers, files=files)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        bb.error(log_error_string + f"[HTTP Error] {e}")
+        bb.error(f"Response: {response.status_code} -> {response.reason}")
+        try:
+            bb.error(f"Response: {response.json()}")
+        except ValueError:
+            pass
+    except requests.exceptions.RequestException as e:
+        bb.error(log_error_string + f"[Error] {e}")
+    else:
+        bb.debug(2, f"File successfully uploaded to {url}")
+
+
+def get_request(bb, url: str, api_key: str, files: dict = None, params: dict = None) -> dict | int | None:
+    headers = {"X-API-Key": api_key}
+    log_error_string = f"Failed to get from Dependency Track server at {url}, {files.keys() = }, {params = }. "
+
+    try:
+        response = requests.get(url, headers=headers, files=files, params=params)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        # for some get requests a 404 is expected, so it is not the error
+        bb.debug(log_error_string + f"[HTTP Error] {e}")
+        bb.debug(f"Response: {response.status_code} -> {response.reason}")
+        try:
+            bb.debug(f"Response: {response.json()}")
+        except ValueError:
+            pass
+
+        return e.response.status_code
+    except requests.exceptions.RequestException as e:
+        bb.error(log_error_string + f"[Error] {e}")
+        return None
+    else:
+        return response.json()

--- a/lib/dependency_track_requests.py
+++ b/lib/dependency_track_requests.py
@@ -3,7 +3,7 @@ import requests
 
 def post_request(bb, url: str, api_key: str, files: dict) -> None:
     headers = {"X-API-Key": api_key}
-    log_error_string = f"Failed to get from Dependency Track server at {url}, {files.keys() = }. "
+    log_error_string = f"Failed to post to Dependency Track server at {url}, {files.keys() = }. "
 
     try:
         response = requests.post(url, headers=headers, files=files)

--- a/lib/dependency_track_requests.py
+++ b/lib/dependency_track_requests.py
@@ -2,15 +2,15 @@ import requests
 import enum
 
 
-def post_request(bb, url: str, api_key: str, files: dict) -> requests.Response:
+def post_request(bb, url: str, api_key: str, files: dict) -> requests.Response | None:
     return _make_request(bb, url, Method.POST, api_key, files=files, json={}, params={})
 
 
-def put_request(bb, url: str, api_key: str, json: dict) -> requests.Response:
+def put_request(bb, url: str, api_key: str, json: dict) -> requests.Response | None:
     return _make_request(bb, url, Method.PUT, api_key, files={}, json=json, params={})
 
 
-def get_request(bb, url: str, api_key: str, params: dict = None) -> requests.Response:
+def get_request(bb, url: str, api_key: str, params: dict = None) -> requests.Response | None:
     return _make_request(bb, url, Method.GET, api_key, files={}, json={}, params=params)
 
 
@@ -21,7 +21,7 @@ class Method(enum.Enum):
 
 
 def _make_request(bb, url: str, method: Method, api_key: str, files: dict, json: dict,
-                  params: dict) -> requests.Response:
+                  params: dict) -> requests.Response | None:
     headers = {"X-API-Key": api_key}
     log_error_string = f"Failed to {method} on Dependency Track server at {url}. {files.keys() = }, {json = }, {params = }. "
 

--- a/lib/dependency_track_requests.py
+++ b/lib/dependency_track_requests.py
@@ -2,14 +2,26 @@ import requests
 import enum
 
 
+def post_request(bb, url: str, api_key: str, files: dict) -> requests.Response:
+    return _make_request(bb, url, Method.POST, api_key, files=files, json={}, params={})
+
+
+def put_request(bb, url: str, api_key: str, json: dict) -> requests.Response:
+    return _make_request(bb, url, Method.PUT, api_key, files={}, json=json, params={})
+
+
+def get_request(bb, url: str, api_key: str, params: dict = None) -> requests.Response:
+    return _make_request(bb, url, Method.GET, api_key, files={}, json={}, params=params)
+
+
 class Method(enum.Enum):
     GET = "GET"
     POST = "POST"
     PUT = "PUT"
 
 
-def make_request(bb, url: str, method: Method, api_key: str, files: dict, json: dict,
-                 params: dict) -> requests.Response:
+def _make_request(bb, url: str, method: Method, api_key: str, files: dict, json: dict,
+                  params: dict) -> requests.Response:
     headers = {"X-API-Key": api_key}
     log_error_string = f"Failed to {method} on Dependency Track server at {url}. {files.keys() = }, {json = }, {params = }. "
 
@@ -41,15 +53,3 @@ def make_request(bb, url: str, method: Method, api_key: str, files: dict, json: 
         bb.debug(2, f"Successful {method} to {url}. Response: {response.json()}")
 
     return response
-
-
-def post_request(bb, url: str, api_key: str, files: dict) -> requests.Response:
-    return make_request(bb, url, Method.POST, api_key, files=files, json={}, params={})
-
-
-def put_request(bb, url: str, api_key: str, json: dict) -> requests.Response:
-    return make_request(bb, url, Method.PUT, api_key, files={}, json=json, params={})
-
-
-def get_request(bb, url: str, api_key: str, params: dict = None) -> requests.Response:
-    return make_request(bb, url, Method.GET, api_key, files={}, json={}, params=params)

--- a/lib/dependency_track_upload.py
+++ b/lib/dependency_track_upload.py
@@ -1,0 +1,164 @@
+import requests
+import time
+from dependency_track_requests import post_request, put_request, get_request
+from urllib.parse import quote
+
+
+def clone_project_and_wait(d, bb) -> None:
+    if project_exists(d, bb):
+        # no error, nothing to do
+        return
+
+    latest_uuid = get_projects_latest_version(d, bb)
+    if not latest_uuid:
+        # error was logged in get_projects_latest_version
+        return
+
+    response = clone_project(d, bb, latest_uuid)
+    if not response:
+        # error was logged in clone_project
+        return
+
+    try:
+        clone_task_id = response.json()["token"]
+    except (ValueError, KeyError):
+        bb.error(f"Failed to parse clone response {response}")
+        return
+    else:
+        while not task_finished(d, bb, clone_task_id):
+            time.sleep(10)
+
+
+def project_exists(d, bb) -> bool:
+    if d.getVar("DEPENDENCYTRACK_PROJECT") != "":
+        # if project's UUID is set then the project exists
+        return True
+
+    dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + "/v1/project/lookup"
+
+    # API return 200 and json project info if project exists and 404 if it doesn't
+    response = get_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), params={
+        "name": d.getVar("DEPENDENCYTRACK_PROJECT_NAME"),
+        "version": d.getVar("DEPENDENCYTRACK_PROJECT_VERSION")
+    })
+    if not response:
+        # error was logged in get_request
+        return False
+
+    if response.status_code == 200:
+        # project was returned
+        return True
+    elif response.status_code == 404:
+        # 404 was returned, expected output for non-existent project
+        return False
+    else:
+        bb.error(f"Failed to check if project exists: {response}")
+
+    return False
+
+
+def get_projects_latest_version(d, bb) -> str | None:
+    if d.getVar("DEPENDENCYTRACK_PROJECT") != "":
+        # if project's UUID is set, version is irrelevant
+        return None
+
+    dt_url = d.getVar(
+        "DEPENDENCYTRACK_API_URL") + f"/v1/project/latest/{quote(d.getVar('DEPENDENCYTRACK_PROJECT_NAME'))}"
+
+    # API returns json with project info which contains {"uuid": str} among other things not used here
+    response = get_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), params={})
+    if not response:
+        # error was logged in get_request
+        return None
+
+    try:
+        latest_uuid = response.json()["uuid"]
+    except (ValueError, KeyError):
+        bb.error(f"Failed to parse project response when getting latest version {response}")
+        return None
+
+    return latest_uuid
+
+
+def clone_project(d, bb, uuid: str) -> requests.Response | None:
+    dt_upload = bb.utils.to_boolean(d.getVar("DEPENDENCYTRACK_UPLOAD"))
+    if not dt_upload:
+        return None
+
+    dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + "/v1/project/clone"
+
+    # API returns {"token": str}
+    return put_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"),
+                       json={"project": uuid, "version": d.getVar("DEPENDENCYTRACK_PROJECT_VERSION"),
+                             "includeACL": True,
+                             "includeAuditHistory": True,
+                             "includeComponents": True,
+                             "includeDependencies": True,
+                             "includePolicyViolations": True,
+                             "includeProperties": True,
+                             "includeServices": True,
+                             "includeTags": True,
+                             "makeCloneLatest": True})
+
+
+def task_finished(d, bb, task_id: str) -> bool:
+    dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + f"/v1/event/token/{task_id}"
+
+    # API returns {"processing": bool}
+    response = get_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), params={})
+    if not response:
+        # error was logged in get_request
+        return True
+
+    try:
+        return not response.json()["processing"]
+    except (ValueError, KeyError):
+        bb.error(f"Failed to parse task ({task_id}) response, {response}")
+
+    return True
+
+
+def upload_sbom(d, bb) -> None:
+    dt_upload = bb.utils.to_boolean(d.getVar("DEPENDENCYTRACK_UPLOAD"))
+    if not dt_upload:
+        return
+
+    dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + "/v1/bom"
+    dt_parent = d.getVar("DEPENDENCYTRACK_PARENT")
+    dt_project = d.getVar("DEPENDENCYTRACK_PROJECT")
+    dt_auto_create = d.getVar("DEPENDENCYTRACK_AUTO_CREATE")
+    dt_project_name = d.getVar("DEPENDENCYTRACK_PROJECT_NAME")
+    dt_project_version = d.getVar("DEPENDENCYTRACK_PROJECT_VERSION")
+    files = {
+        "parentUUID": dt_parent,
+        "autoCreate": dt_auto_create,
+        "bom": open(d.getVar("DEPENDENCYTRACK_SBOM"), 'rb')
+    }
+
+    if dt_project == "":
+        files["projectName"] = dt_project_name
+        files["projectVersion"] = dt_project_version
+    else:
+        files["project"] = dt_project
+
+    post_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), files=files)
+
+
+def upload_vex(d, bb) -> None:
+    dt_upload = bb.utils.to_boolean(d.getVar("DEPENDENCYTRACK_UPLOAD"))
+    if not dt_upload:
+        return
+
+    dt_url = d.getVar("DEPENDENCYTRACK_API_URL") + "/v1/vex"
+    dt_project = d.getVar("DEPENDENCYTRACK_PROJECT")
+    dt_project_name = d.getVar("DEPENDENCYTRACK_PROJECT_NAME")
+    dt_project_version = d.getVar("DEPENDENCYTRACK_PROJECT_VERSION")
+    files = {"vex": open(d.getVar("DEPENDENCYTRACK_VEX"), "rb")}
+
+    if dt_project == "":
+        files["projectName"] = dt_project_name
+        files["projectVersion"] = dt_project_version
+    else:
+        files["project"] = dt_project
+
+    post_request(bb, dt_url, d.getVar("DEPENDENCYTRACK_API_KEY"), files=files)

--- a/lib/dependency_track_upload.py
+++ b/lib/dependency_track_upload.py
@@ -130,11 +130,12 @@ def upload_sbom(d, bb) -> None:
     dt_auto_create = d.getVar("DEPENDENCYTRACK_AUTO_CREATE")
     dt_project_name = d.getVar("DEPENDENCYTRACK_PROJECT_NAME")
     dt_project_version = d.getVar("DEPENDENCYTRACK_PROJECT_VERSION")
-    files = {
-        "parentUUID": dt_parent,
-        "autoCreate": dt_auto_create,
-        "bom": open(d.getVar("DEPENDENCYTRACK_SBOM"), 'rb')
-    }
+    with open(d.getVar("DEPENDENCYTRACK_SBOM"), 'rb') as sbom_file:
+        files = {
+            "parentUUID": dt_parent,
+            "autoCreate": dt_auto_create,
+            "bom": sbom_file.read()
+        }
 
     if dt_project == "":
         files["projectName"] = dt_project_name
@@ -154,7 +155,8 @@ def upload_vex(d, bb) -> None:
     dt_project = d.getVar("DEPENDENCYTRACK_PROJECT")
     dt_project_name = d.getVar("DEPENDENCYTRACK_PROJECT_NAME")
     dt_project_version = d.getVar("DEPENDENCYTRACK_PROJECT_VERSION")
-    files = {"vex": open(d.getVar("DEPENDENCYTRACK_VEX"), "rb")}
+    with open(d.getVar("DEPENDENCYTRACK_VEX"), "rb") as vex_file:
+        files = {"vex": vex_file.read()}
 
     if dt_project == "":
         files["projectName"] = dt_project_name

--- a/lib/dependency_track_upload.py
+++ b/lib/dependency_track_upload.py
@@ -16,7 +16,7 @@ def clone_project_and_wait(d, bb) -> None:
 
     response = clone_project(d, bb, latest_uuid)
     if not response:
-        # error was logged in clone_project
+        # error was logged in clone_project or no upload needed
         return
 
     try:
@@ -26,6 +26,7 @@ def clone_project_and_wait(d, bb) -> None:
         return
     else:
         while not task_finished(d, bb, clone_task_id):
+            bb.debug(2, "Waiting for project clone to finish...")
             time.sleep(10)
 
 

--- a/lib/json_utils.py
+++ b/lib/json_utils.py
@@ -1,0 +1,26 @@
+import json
+import pathlib
+
+
+def read_json(path: str) -> dict:
+    return json.loads(pathlib.Path(path).read_text())
+
+
+def write_json(path: str, data: dict) -> None:
+    pathlib.Path(path).write_text(json.dumps(data, indent=2))
+
+
+def read_sbom(d):
+    return read_json(d.getVar("DEPENDENCYTRACK_SBOM"))
+
+
+def write_sbom(d, sbom):
+    write_json(d.getVar("DEPENDENCYTRACK_SBOM"), sbom)
+
+
+def read_vex(d):
+    return read_json(d.getVar("DEPENDENCYTRACK_VEX"))
+
+
+def write_vex(d, vex):
+    write_json(d.getVar("DEPENDENCYTRACK_VEX"), vex)

--- a/lib/sbom_details.py
+++ b/lib/sbom_details.py
@@ -31,8 +31,7 @@ def get_cpe_ids(cve_product: str, version: str, part: str) -> list:
 
 
 def get_references(src_uris: list) -> list:
-    pattern = re.compile(
-        r"https?://[a-z.]*/[a-z.\-/_]*[a-z.\-_].(tar.([gxl]?z|bz2)|tgz)")
+    pattern = re.compile(r"https?://[a-z.]*/[a-z.\-/_]*[a-z.\-_].(tar.([gxl]?z|bz2)|tgz)")
     refs = []
     for src in src_uris:
         if src.startswith("git://") or src.endswith(".git"):
@@ -55,12 +54,12 @@ def get_licenses(d):
     if license_expression:
         license_json = []
         licenses = license_expression.replace("|", "").replace("&", "").split()
-        for license in licenses:
-            converted_license = license_conversion_map.get(license, license)
+        for original_license in licenses:
+            converted_license = license_conversion_map.get(original_license, original_license)
             # Search for the license in COMMON_LICENSE_DIR and LICENSE_PATH
             for directory in [d.getVar("COMMON_LICENSE_DIR")] + (d.getVar("LICENSE_PATH") or "").split():
                 try:
-                    with (pathlib.Path(directory) / converted_license).open(errors="replace") as f:
+                    with (pathlib.Path(directory) / converted_license).open(errors="replace"):
                         license_data = {"license": {"name": converted_license}}
                         license_json.append(license_data)
                         break

--- a/lib/sbom_details.py
+++ b/lib/sbom_details.py
@@ -1,0 +1,70 @@
+import pathlib
+import re
+import hashlib
+import uuid
+
+
+def get_bom_ref(value) -> str:
+    return str(uuid.UUID(hashlib.md5(value.encode()).hexdigest()))
+
+
+def get_cpe_ids(cve_product: str, version: str, part: str) -> list:
+    """
+    Get list of CPE identifiers for the given product and version
+    """
+
+    cpe_ids = []
+    for product in cve_product.split():
+        # CVE_PRODUCT in recipes may include vendor information for CPE identifiers. If not,
+        # use wildcard for vendor.
+        if ":" in product:
+            vendor, product = product.split(":", 1)
+        else:
+            vendor = "*"
+
+        cpe_id = 'cpe:2.3:{}:{}:{}:{}:*:*:*:*:*:*:*'.format(
+            part, vendor, product, version)
+        cpe_ids.append(type('', (object,), {
+            "cpe": cpe_id, "product": product, "vendor": vendor if vendor != "*" else ""})())
+
+    return cpe_ids
+
+
+def get_references(src_uris: list) -> list:
+    pattern = re.compile(
+        r"https?://[a-z.]*/[a-z.\-/_]*[a-z.\-_].(tar.([gxl]?z|bz2)|tgz)")
+    refs = []
+    for src in src_uris:
+        if src.startswith("git://") or src.endswith(".git"):
+            refs.append({"type": "vcs", "url": src})
+
+        elif pattern.match(src):
+            refs.append({"type": "source-distribution", "url": src})
+
+        elif src.startswith("http://") or src.startswith("https://"):
+            refs.append({"type": "website", "url": src})
+
+    return refs
+
+
+def get_licenses(d):
+    license_conversion_map = {"GPLv2+": "GPL-2.0-or-later", "GPLv2": "GPL-2.0", "LGPLv2": "LGPL-2.0",
+                              "LGPLv2+": "LGPL-2.0-or-later", "LGPLv2.1+": "LGPL-2.1-or-later", "LGPLv2.1": "LGPL-2.1"}
+
+    license_expression = d.getVar("LICENSE")
+    if license_expression:
+        license_json = []
+        licenses = license_expression.replace("|", "").replace("&", "").split()
+        for license in licenses:
+            converted_license = license_conversion_map.get(license, license)
+            # Search for the license in COMMON_LICENSE_DIR and LICENSE_PATH
+            for directory in [d.getVar("COMMON_LICENSE_DIR")] + (d.getVar("LICENSE_PATH") or "").split():
+                try:
+                    with (pathlib.Path(directory) / converted_license).open(errors="replace") as f:
+                        license_data = {"license": {"name": converted_license}}
+                        license_json.append(license_data)
+                        break
+                except FileNotFoundError:
+                    pass
+        return license_json
+    return None

--- a/lib/vex_handling.py
+++ b/lib/vex_handling.py
@@ -1,0 +1,30 @@
+def add_ignored_vulnerability(vex: dict, cve_id: str) -> None:
+    if next((v for v in vex["vulnerabilities"] if v["id"] == cve_id), None) is None:
+        add_vulnerability(vex, cve_id, "resolved", "will_not_fix",
+                          "CVE_CHECK data : The vulnerability has been Ignored!", "code_not_present")
+
+
+def add_patched_vulnerability(vex: dict, cve_id: str) -> None:
+    vulnerability = next(
+        (v for v in vex["vulnerabilities"] if v["id"] == cve_id), None)
+    if vulnerability is None:
+        add_vulnerability(vex, cve_id, "resolved", "update",
+                          "CVE_CHECK data : The vulnerability has been Patched!")
+    else:  # (write to patched, even if already ignored)
+        vulnerability["analysis"].update({"state": "resolved", "response": [
+            "update"], "detail": "CVE_CHECK data: The vulnerability has been Patched!"})
+
+
+def add_vulnerability(vex: dict, cve_id: str, analysis_state: str, analysis_response: str, analysis_detail: str,
+                      analysis_justification: str = None) -> None:
+    vulnerability = {
+        "id": cve_id,
+        "source": {"name": "NVD", "url": "https://nvd.nist.gov/"},
+        "analysis": {"state": analysis_state, "response": [analysis_response], "detail": analysis_detail},
+        "affects": [{"ref": vex["metadata"]["component"]["bom-ref"]}]
+    }
+
+    if analysis_justification:
+        vulnerability["analysis"]["justification"] = analysis_justification
+
+    vex["vulnerabilities"].append(vulnerability)

--- a/lib/vex_handling.py
+++ b/lib/vex_handling.py
@@ -1,7 +1,7 @@
 def add_ignored_vulnerability(vex: dict, cve_id: str) -> None:
     if next((v for v in vex["vulnerabilities"] if v["id"] == cve_id), None) is None:
         add_vulnerability(vex, cve_id, "resolved", "will_not_fix",
-                          "CVE_CHECK data : The vulnerability has been Ignored!", "code_not_present")
+                          "CVE_CHECK data: The vulnerability has been Ignored!", "code_not_present")
 
 
 def add_patched_vulnerability(vex: dict, cve_id: str) -> None:


### PR DESCRIPTION
The following was changed:
- Do not upload empty SBOM every time build starts
- Created multiple python files to store more logic instead of storing everything in 1 bbclass file
- After the SBOM is finished in the upload step the build now checks if the project exists and creates a clone on the latest version (which stores all vulnerabilities + analysis). The clone operation takes some time, but is relatively fast (experiments show up to a minute) so the build would wait until the operation is done checking the token every 10 seconds

Known issues:
- the init and upload step is run twice. Not causing a lot of issues as of now, might even help with dependency track not finding some vulnerabilities fast enough. Since clone checks if the project exists the second time it is not triggered
- Based on dependency track behavior in case a new component is added into a new version it is still possible that it will miss a component due to sync issue. InternalAnalysisTask's token is not available to see if BOM analysis is finished, but cloning should help a lot with the vulnerabilities that were missed